### PR TITLE
Add axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "homepage": "/",
   "dependencies": {
+    "axios": "^0.19.0",
     "customize-cra": "^0.8.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",


### PR DESCRIPTION
There's an error in the Flup library because it use this repository like a boilerplate and require the use of `axios`.
Now was added axios in the `package.json` to fix the error.



